### PR TITLE
skip SonarCloud and Claude Code Review for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   claude-review:
+    # skips for Dependabot PRs as secrets are not available
+    if: github.actor != 'dependabot[bot]'
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -18,6 +18,8 @@ concurrency:
 
 jobs:
   sonarcloud:
+    # skips for Dependabot PRs as secrets are not available
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
adds conditional checks to skip both workflows when the PR author is dependabot[bot], as these workflows require secrets that are not available to Dependabot PRs for security reasons